### PR TITLE
816 mask の gesture が効かない

### DIFF
--- a/src/Itinerary/Pages/IPA001ItineraryEdit/ItineraryEdit.tsx
+++ b/src/Itinerary/Pages/IPA001ItineraryEdit/ItineraryEdit.tsx
@@ -47,7 +47,7 @@ export const IPA001ItineraryEdit = ({ route, navigation }: ItineraryTopTabScreen
 			<CCO007GoogleBannerAd />
 			<Pressable onPress={onPressThumbnail}>
 				<MaterialCommunityIcons
-					name="camera-outline"
+					name="square-edit-outline"
 					size={100}
 					color="rgba(0,0,0,0.5)"
 					style={styles.materialCommunityIcons}

--- a/src/Itinerary/Pages/IPA003EditPlan/EditPlan.tsx
+++ b/src/Itinerary/Pages/IPA003EditPlan/EditPlan.tsx
@@ -45,7 +45,7 @@ export const IPA003EditPlan = ({ route, navigation }: ItineraryStackScreenProps<
 			<CCO007GoogleBannerAd />
 			<Pressable onPress={onPressThumbnail}>
 				<MaterialCommunityIcons
-					name="camera-outline"
+					name="square-edit-outline"
 					size={100}
 					color="rgba(0,0,0,0.5)"
 					style={styles.materialCommunityIcons}

--- a/src/Thumbnail/Components/TCO001GestureProvider/GestureProviderController.ts
+++ b/src/Thumbnail/Components/TCO001GestureProvider/GestureProviderController.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useAnimatedStyle } from 'react-native-reanimated';
 
 import { GestureProviderPropsInterface } from '@/Thumbnail/Components/TCO001GestureProvider/GestureProviderPropsInterface';
@@ -5,6 +6,28 @@ import { GestureProviderPropsInterface } from '@/Thumbnail/Components/TCO001Gest
 interface UseAnimatedStyleInterface extends Pick<GestureProviderPropsInterface, 'gesture' | 'canvasSize'> {
 	componentSize?: { width: number; height: number } | undefined;
 }
+
+export const TCO001CalcAnimatedGesture = ({
+	canvasSize,
+	componentSize,
+}: Required<Pick<UseAnimatedStyleInterface, 'canvasSize' | 'componentSize'>>) => {
+	const getTranslateX = useCallback(
+		(translateX: number) => translateX * canvasSize.width - componentSize.width / 2,
+		[canvasSize.width, componentSize?.width],
+	);
+	const getTranslateY = useCallback(
+		(translateY: number) => translateY * canvasSize.height - componentSize.height / 2,
+		[canvasSize.height, componentSize?.height],
+	);
+	const getScale = useCallback((scale: number) => scale, []);
+	const getRotateZ = useCallback((rotateZ: number) => `${(rotateZ / Math.PI) * 180}deg`, []);
+	return {
+		getTranslateX,
+		getTranslateY,
+		getScale,
+		getRotateZ,
+	};
+};
 
 export const TCO001UseAnimatedStyle = ({
 	gesture,
@@ -14,17 +37,21 @@ export const TCO001UseAnimatedStyle = ({
 		height: 0,
 	},
 }: UseAnimatedStyleInterface) => {
-	const { translateX, translateY, scale, rotateZ } = gesture;
+	const { getTranslateX, getTranslateY, getScale, getRotateZ } = TCO001CalcAnimatedGesture({
+		canvasSize,
+		componentSize,
+	});
+
 	const animatedStyle = useAnimatedStyle(() => ({
 		transform: [
 			{
-				translateX: translateX.value * canvasSize.width - componentSize.width / 2,
+				translateX: getTranslateX(gesture.translateX.value),
 			},
 			{
-				translateY: translateY.value * canvasSize.height - componentSize.height / 2,
+				translateY: getTranslateY(gesture.translateY.value),
 			},
-			{ scale: scale.value },
-			{ rotateZ: `${(rotateZ.value / Math.PI) * 180}deg` },
+			{ scale: getScale(gesture.scale.value) },
+			{ rotateZ: getRotateZ(gesture.rotateZ.value) },
 		],
 	}));
 

--- a/src/Thumbnail/Contexts/TCT023DecorationsMap/DecorationsMap.tsx
+++ b/src/Thumbnail/Contexts/TCT023DecorationsMap/DecorationsMap.tsx
@@ -24,6 +24,8 @@ export const TCT023DecorationsMapProvider = ({ children }: { children: ReactNode
 				Decorations,
 				(model) => {
 					const decorationType = model.decorationType as DecorationsMapInterface['decorationType'];
+					model.maskTransform.translateX = 0.5;
+					model.maskTransform.translateY = 0.5;
 					return {
 						...model,
 						decorationType,

--- a/src/Thumbnail/Contexts/TCT023DecorationsMap/ModelComponents/TMC02301Decoration/Decoration.tsx
+++ b/src/Thumbnail/Contexts/TCT023DecorationsMap/ModelComponents/TMC02301Decoration/Decoration.tsx
@@ -92,7 +92,8 @@ export const TMC02301Decoration = ({ decorationID, onLoad, canvasSize }: Decorat
 	/*
 	 * デコレーションのサイズを取得する
 	 * Text の場合、FontSize を固定したいため、 onLayout を使用する。
-	 * Image, Figure の場合、 width を固定したいため、canvasSize と aspectRatio を使用する。
+	 * Image, Figure の場合、 canvasSize.width が decorationSize.width となる。
+	 * decorationSize.height は、 decoration.aspectRatio から計算する。
 	 */
 	const [decorationSize, setDecorationSize] = useState<
 		| {

--- a/src/Thumbnail/Contexts/TCT023DecorationsMap/ModelComponents/TMC02302MaskedDecoration/MaskedDecoration.web.tsx
+++ b/src/Thumbnail/Contexts/TCT023DecorationsMap/ModelComponents/TMC02302MaskedDecoration/MaskedDecoration.web.tsx
@@ -5,6 +5,8 @@ import { TCT023DecorationsMap } from '../../DecorationsMap';
 
 import { MaskedDecorationPropsInterface } from './MaskedDecorationInterface';
 
+import { TCO001CalcAnimatedGesture } from '@/Thumbnail/Components/TCO001GestureProvider/GestureProviderController';
+
 export const TMC02302MaskedDecoration = ({
 	decorationID,
 	value,
@@ -14,6 +16,15 @@ export const TMC02302MaskedDecoration = ({
 	const { decorationsMap } = useContext(TCT023DecorationsMap);
 	const decoration = decorationsMap[decorationID];
 	const maskRef = useRef<HTMLImageElement>(null);
+	const { getTranslateX, getTranslateY, getScale } = TCO001CalcAnimatedGesture({
+		canvasSize: containerSize,
+		componentSize: {
+			// mask 画像のサイズは、containerSize の小さい方に合わせた正方形とする
+			// maskTransform.scale によって、mask 画像のサイズが変わる
+			width: Math.min(containerSize.width, containerSize.height) * (decoration?.maskTransform.scale || 0),
+			height: Math.min(containerSize.width, containerSize.height) * (decoration?.maskTransform.scale || 0),
+		},
+	});
 	const setMasRef = useCallback(() => {
 		if (!maskRef.current) return;
 		maskRef.current.style.webkitMaskRepeat = 'no-repeat';
@@ -23,14 +34,18 @@ export const TMC02302MaskedDecoration = ({
 		if (!decoration?.maskUri) return;
 		maskRef.current.style.webkitMaskImage = `url(${decoration.maskUri})`;
 		maskRef.current.style.maskImage = `url(${decoration.maskUri})`;
-		maskRef.current.style.maskPosition = `${decoration.maskTransform.translateX * containerSize.width}px ${
-			decoration.maskTransform.translateY * containerSize.height
+		const maskPosition = `${
+			decoration.maskTransform.translateX * containerSize.width -
+			(Math.min(containerSize.width, containerSize.height) * decoration.maskTransform.scale) / 2
+		}px ${
+			decoration.maskTransform.translateY * containerSize.height -
+			(Math.min(containerSize.width, containerSize.height) * decoration.maskTransform.scale) / 2
 		}px`;
-		maskRef.current.style.webkitMaskPosition = `${decoration.maskTransform.translateX * containerSize.width}px ${
-			decoration.maskTransform.translateY * containerSize.height
-		}px`;
-		maskRef.current.style.webkitMaskSize = 'auto 100%';
-		maskRef.current.style.maskSize = 'auto 100%';
+		maskRef.current.style.maskPosition = maskPosition;
+		maskRef.current.style.webkitMaskPosition = maskPosition;
+		const maskSize = `auto ${decoration.maskTransform.scale * 100}%`;
+		maskRef.current.style.webkitMaskSize = maskSize;
+		maskRef.current.style.maskSize = maskSize;
 	}, [containerSize.height, containerSize.width, decoration?.maskTransform, decoration?.maskUri]);
 	useEffect(() => {
 		if (!decoration) return;
@@ -57,10 +72,10 @@ export const TMC02302MaskedDecoration = ({
 				<div
 					style={{
 						width: containerSize.width,
-						aspectRatio: decoration.aspectRatio,
 						backgroundColor: decoration.color,
-						borderWidth: 1,
 						borderColor: decoration.borderColor,
+						aspectRatio: decoration.aspectRatio,
+						borderWidth: 1,
 						borderStyle: 'solid',
 					}}
 					ref={maskRef}

--- a/src/Thumbnail/Pages/TPA001ThumbnailEditor/Controller/CreateDecorationController.ts
+++ b/src/Thumbnail/Pages/TPA001ThumbnailEditor/Controller/CreateDecorationController.ts
@@ -36,8 +36,8 @@ export const TPA001CreateDecorationController = ({
 				scale: 1 / 3,
 			},
 			maskTransform: {
-				translateX: 0,
-				translateY: 0,
+				translateX: 0.5,
+				translateY: 0.5,
 				rotateZ: 0,
 				scale: 1,
 			},
@@ -46,7 +46,7 @@ export const TPA001CreateDecorationController = ({
 			aspectRatio: 1,
 		}),
 		[],
-	); // TODO: 要修正 translateX, translateY は 中央に
+	);
 
 	const onPickImage: ImagePickerPropsInterface['onPickImage'] = useCallback(
 		(imageUrl) => {

--- a/src/Thumbnail/Pages/TPA001ThumbnailEditor/MaskDialog/MaskDialogController.ts
+++ b/src/Thumbnail/Pages/TPA001ThumbnailEditor/MaskDialog/MaskDialogController.ts
@@ -6,6 +6,7 @@ import { Decorations } from 'spelieve-common/lib/Models/Thumbnail/TDB02/Decorati
 import { MaskDecorationPropsInterface } from './MaskDecoration/MaskDecorationInterface';
 import { TPA001MaskDialogPropsInterface } from './MaskDialogInterface';
 
+import { Logger } from '@/Common/Hooks/CHK001Utils';
 import { GestureProviderPropsInterface } from '@/Thumbnail/Components/TCO001GestureProvider/GestureProviderPropsInterface';
 import { TCT023DecorationsMap } from '@/Thumbnail/Contexts/TCT023DecorationsMap/DecorationsMap';
 import { DecorationsMapInterface } from '@/Thumbnail/Contexts/TCT023DecorationsMap/DecorationsMapInterface';
@@ -89,6 +90,7 @@ export const TPA001MaskDialogController = ({
 	});
 
 	const onLayout = useCallback((event: LayoutChangeEvent) => {
+		Logger('MaskDialogController', 'onLayout', event.nativeEvent.layout);
 		setComponentSize(event.nativeEvent.layout);
 	}, []);
 


### PR DESCRIPTION
## Web で、Mask の Gesture が効かない課題対応
* TCO001UseAnimatedStyle から計算部分を切り出し
* maskTransform.translateX を倍率に修正
   * 初期値修正
* TMC02302MaskedDecoration.web の設計見直し
* TPA001MaskDecoration.web の設計見直し

## Thumbnail 遷移のための Pressable はカメラアイコンより鉛筆アイコンの方が適切のため修正
