### PR TITLE
広告のサイズを修正

### DIFF
--- a/src/Common/Components/CCO007GoogleBannerAd/GoogleBannerAd.tsx
+++ b/src/Common/Components/CCO007GoogleBannerAd/GoogleBannerAd.tsx
@@ -13,7 +13,7 @@ const adUnitID = ENV.LOGGER ? TestIds.BANNER : ProductionAdUnitID;
 export const CCO007GoogleBannerAd = () => (
 	<BannerAd
 		unitId={adUnitID}
-		size={BannerAdSize.FULL_BANNER}
+		size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
 		requestOptions={{
 			requestNonPersonalizedAdsOnly: true,
 		}}


### PR DESCRIPTION
# issue
#864 

# 修正点
Bannarサイズ以下のように変更
FULL_BANNER→ANCHORED_ADAPTIVE_BANNER

**FULL_BANNER:** 
> Interactive Advertising Bureau (IAB) full banner ad size (468x60 density-independent pixels).
画面サイズとかに関係なく、468x60になる

**ANCHORED_ADAPTIVE_BANNER:** 
> A (next generation) dynamically sized banner that is full-width and auto-height.
高さは自動、画面幅いっぱいになる

[Bannerサイズ一覧](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/BannerAdSize.ts)

# 動作確認
![広告修正](https://github.com/Ayato-kosaka/spelieve/assets/75763679/26dfbdfe-a138-494e-8cd7-9ff0c433a007)
