### PR TITLE
#884 Preview に URL で飛ぶと、Edit に遷移できなくなる

### DIFF
--- a/src/Itinerary/Pages/IPA001ItineraryEdit/ItineraryEditController.ts
+++ b/src/Itinerary/Pages/IPA001ItineraryEdit/ItineraryEditController.ts
@@ -21,7 +21,7 @@ export const IPA001ItineraryEditController = ({ route, navigation }: ItineraryTo
 	const { plansCRef } = useContext(ICT031PlansMap);
 
 	// eslint-disable-next-line @typescript-eslint/naming-convention
-	const { itineraryID, place_id, placeName, placeImage } = route.params;
+	const { place_id, placeName, placeImage } = route.params;
 
 	const createItinerary = useCallback(async () => {
 		if (itineraryCRef) {
@@ -45,13 +45,17 @@ export const IPA001ItineraryEditController = ({ route, navigation }: ItineraryTo
 	}, [itineraryCRef, navigation, planGroupsCRef, plansCRef]);
 
 	useEffect(() => {
-		if (itineraryID) {
-			setItineraryID(itineraryID);
+		if (route.params.itineraryID) {
+			if (!itineraryDocSnap?.id) {
+				setItineraryID(route.params.itineraryID);
+			}
+		} else if (itineraryDocSnap?.id) {
+			navigation.setParams({ itineraryID: itineraryDocSnap?.id });
 		} else {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			createItinerary();
 		}
-	}, [createItinerary, itineraryID, setItineraryID]);
+	}, [createItinerary, itineraryDocSnap?.id, navigation, route.params.itineraryID, setItineraryID]);
 
 	useEffect(() => {
 		if (planGroupsQSnap?.empty) {
@@ -157,20 +161,20 @@ export const IPA001ItineraryEditController = ({ route, navigation }: ItineraryTo
 	const onPlanPress = useCallback(
 		(planGroupID: string, planID: string) => {
 			navigation.navigate('EditPlan', {
-				itineraryID,
+				itineraryID: itineraryDocSnap?.id,
 				planGroupID,
 				planID,
 			});
 		},
-		[navigation, itineraryID],
+		[navigation, itineraryDocSnap?.id],
 	);
 
-	const buildCopyItineraryPreviewDL = async () => {
-		if (!itineraryID) return;
-		const previewPageLink = `${ENV.HOST_NAME_WEB}/ItineraryPreview?itineraryID=${itineraryID}`;
+	const buildCopyItineraryPreviewDL = useCallback(async () => {
+		if (!itineraryDocSnap?.id) return;
+		const previewPageLink = `${ENV.HOST_NAME_WEB}/ItineraryPreview?itineraryID=${itineraryDocSnap?.id}`;
 		const url = Platform.OS !== 'web' ? await buildDynamicLink(previewPageLink) : previewPageLink;
 		await setStringAsync(url);
-	};
+	}, [itineraryDocSnap?.id]);
 
 	return {
 		pageItinerary,


### PR DESCRIPTION
## 対応内容
itineraryID を初期セットするロジックを ItineraryPreview に合わせて修正 また、ItineraryEdit で用いられる itineraryID という変数が、　route.params.itineraryID なのか itineraryDocSnap?.id なのか判断が難しいので変数を消去

## エビデンス
観点は以下
* Itinerary 新規作成で正しく遷移されること
* URL で ItineraryEdit に正しく遷移されること
* URL で ItineraryPreview -> ItineraryEdit に正しく遷移されること
* buildCopyItineraryPreviewDL でコピーされた値で ItineraryPreview に正しく遷移されること
[Spelieve-旅のしおり簡単作成アプリ-.webm](https://github.com/Ayato-kosaka/spelieve/assets/53715839/129ce3f3-91f8-445e-8a0f-1a4b7b6cb892)

