### PR TITLE
#886 一番上にプランを作るボタンがない

### DIFF
--- a/src/Itinerary/Contexts/ICT021PlanGroupsList/PlanGroupsList.tsx
+++ b/src/Itinerary/Contexts/ICT021PlanGroupsList/PlanGroupsList.tsx
@@ -1,10 +1,8 @@
-import { TransitMode, TransitRoutingPreference } from '@googlemaps/google-maps-services-js';
 import { collection, query, QuerySnapshot, onSnapshot, addDoc, orderBy, setDoc, deleteDoc } from 'firebase/firestore';
 import { useState, createContext, useEffect, useContext, useMemo, ReactNode, useCallback } from 'react';
 
 import { PlanGroups } from 'spelieve-common/lib/Models/Itinerary/IDB02/PlanGroups';
 import { Plans } from 'spelieve-common/lib/Models/Itinerary/IDB03/Plans';
-import * as DateUtils from 'spelieve-common/lib/Utils/DateUtils';
 import { FirestoreConverter } from 'spelieve-common/lib/Utils/FirestoreConverter';
 
 import { PlanGroupsListInterface, PlanGroupsListValInterface } from './PlanGroupsListInterface';
@@ -18,7 +16,7 @@ export const ICT021PlanGroupsListProvider = ({ children }: { children: ReactNode
 	const [planGroupsQSnap, setPlanGroupsQSnap] = useState<QuerySnapshot<PlanGroupsListInterface> | undefined>(undefined);
 
 	const { itineraryDocSnap } = useContext(ICT011ItineraryOne);
-	const { plansCRef, plansDocSnapMap } = useContext(ICT031PlansMap);
+	const { plansCRef, plansDocSnapMap, createPlan } = useContext(ICT031PlansMap);
 
 	const itinerary = useMemo(() => itineraryDocSnap?.data(), [itineraryDocSnap]);
 
@@ -47,25 +45,15 @@ export const ICT021PlanGroupsListProvider = ({ children }: { children: ReactNode
 
 	const createPlanGroup = useCallback(
 		async (plan?: Partial<Plans>) => {
-			if (!plansCRef || !planGroupsCRef || !itinerary) {
+			if (!planGroupsCRef || !itinerary) {
 				throw new Error('not initialized');
 			}
-			const newPlan: Plans = {
-				title: '',
-				placeSpan: DateUtils.initialDate(),
+			const newPlan = {
 				placeStartTime: itinerary.startDate,
 				placeEndTime: itinerary.startDate,
-				transportationSpan: DateUtils.initialDate(),
-				avoid: [],
-				transitModes: [TransitMode.bus, TransitMode.rail, TransitMode.subway, TransitMode.train, TransitMode.tram],
-				transitRoutingPreference: TransitRoutingPreference.fewer_transfers,
-				textMap: {},
-				storeUrlMap: {},
-				createdAt: new Date(),
-				updatedAt: new Date(),
 				...plan,
 			};
-			const planDocRef = await addDoc(plansCRef, newPlan);
+			const planDocRef = await createPlan(newPlan);
 			await addDoc(planGroupsCRef, {
 				plans: [planDocRef.id],
 				representativePlanID: planDocRef.id,
@@ -75,7 +63,7 @@ export const ICT021PlanGroupsListProvider = ({ children }: { children: ReactNode
 				updatedAt: new Date(),
 			});
 		},
-		[itinerary, planGroupsCRef, plansCRef],
+		[createPlan, itinerary, planGroupsCRef],
 	);
 
 	const movePlan = useCallback(

--- a/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03102TrafficMovementEdit/TrafficMovementEdit.tsx
+++ b/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03102TrafficMovementEdit/TrafficMovementEdit.tsx
@@ -9,6 +9,7 @@ import { ICT031PlansMap } from '../..';
 
 import { IMC03102TrafficMovementEditController } from './TrafficMovementEditController';
 import { TrafficMovementEditPropsInterface } from './TrafficMovementEditInterface';
+import { IMC03102TrafficMovementEditTemplate } from './TrafficMovementEditTemplate';
 
 import i18n from '@/Common/Hooks/i18n-js';
 import { IMC03104EditDirectionsMode } from '@/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03104EditDirectionsMode';
@@ -42,9 +43,10 @@ export const IMC03102TrafficMovementEdit = ({
 
 	return (
 		<>
-			<View style={{ flexDirection: 'row', paddingHorizontal: 16, paddingVertical: 4 }}>
-				<View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-					{plan.place_id && nextPlan?.place_id && (
+			<IMC03102TrafficMovementEditTemplate
+				Mode={
+					plan.place_id &&
+					nextPlan?.place_id && (
 						<Pressable
 							onPress={() => {
 								setBottomSheetVisible(true);
@@ -58,38 +60,38 @@ export const IMC03102TrafficMovementEdit = ({
 								size={20}
 							/>
 						</Pressable>
-					)}
-				</View>
-				<View style={{ flex: 14, flexDirection: 'row' }}>
-					<View style={{ flex: 3 }}>
-						{plan.place_id && nextPlan?.place_id && plan.transportationMode && (
-							<View>
-								<Text>
-									{plan.transportationDepartureTime
-										? `${DateUtils.formatToHHMM(plan.transportationDepartureTime)} ~`
-										: ''}
-								</Text>
-								<Text>
-									{plan.transportationArrivalTime ? `${DateUtils.formatToHHMM(plan.transportationArrivalTime)}` : ''}
-								</Text>
-							</View>
-						)}
-					</View>
-					<View style={{ flex: 11, flexDirection: 'row' }}>
-						<Button
-							mode="outlined"
-							icon="plus"
-							onPress={() => {
-								// eslint-disable-next-line @typescript-eslint/no-floating-promises
-								addPlan();
-							}}
-							color={materialColors.grey['500']}
-							style={{ backgroundColor: 'white' }}>
-							{i18n.t('Add Plan')}
-						</Button>
-					</View>
-				</View>
-			</View>
+					)
+				}
+				Time={
+					plan.place_id &&
+					nextPlan?.place_id &&
+					plan.transportationMode && (
+						<View>
+							<Text>
+								{plan.transportationDepartureTime
+									? `${DateUtils.formatToHHMM(plan.transportationDepartureTime)} ~`
+									: ''}
+							</Text>
+							<Text>
+								{plan.transportationArrivalTime ? `${DateUtils.formatToHHMM(plan.transportationArrivalTime)}` : ''}
+							</Text>
+						</View>
+					)
+				}
+				AddPlan={
+					<Button
+						mode="outlined"
+						icon="plus"
+						onPress={() => {
+							// eslint-disable-next-line @typescript-eslint/no-floating-promises
+							addPlan();
+						}}
+						color={materialColors.grey['500']}
+						style={{ backgroundColor: 'white' }}>
+						{i18n.t('Add Plan')}
+					</Button>
+				}
+			/>
 			<IMC03104EditDirectionsMode
 				planID={planID}
 				bottomSheetVisible={bottomSheetVisible}

--- a/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03102TrafficMovementEdit/TrafficMovementEditTemplate.tsx
+++ b/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03102TrafficMovementEdit/TrafficMovementEditTemplate.tsx
@@ -1,0 +1,19 @@
+import { View } from 'react-native';
+
+export const IMC03102TrafficMovementEditTemplate = ({
+	Mode,
+	Time,
+	AddPlan,
+}: {
+	Mode: React.ReactNode | undefined;
+	Time: React.ReactNode | undefined;
+	AddPlan: React.ReactNode | undefined;
+}) => (
+	<View style={{ flexDirection: 'row', paddingHorizontal: 16, paddingVertical: 4 }}>
+		<View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>{Mode}</View>
+		<View style={{ flex: 14, flexDirection: 'row' }}>
+			<View style={{ flex: 3 }}>{Time}</View>
+			<View style={{ flex: 11, flexDirection: 'row' }}>{AddPlan}</View>
+		</View>
+	</View>
+);

--- a/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03103PlanGroupEdit/PlanGroupEdit.tsx
+++ b/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03103PlanGroupEdit/PlanGroupEdit.tsx
@@ -1,12 +1,14 @@
 import { useMemo } from 'react';
 import { View } from 'react-native';
-import { Card } from 'react-native-paper';
+import { Card, Button } from 'react-native-paper';
 
 import { IMC03103PlanGroupsEditController } from './PlanGroupsEditController';
 import { PlanGroupsEditPropsInterface } from './PlanGroupsEditPropsInterface';
 
+import i18n from '@/Common/Hooks/i18n-js';
 import { IMC03101PlanEdit } from '@/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03101PlanEdit';
 import { IMC03102TrafficMovementEdit } from '@/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03102TrafficMovementEdit/TrafficMovementEdit';
+import { IMC03102TrafficMovementEditTemplate } from '@/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03102TrafficMovementEdit/TrafficMovementEditTemplate';
 import { materialColors, primaryColorNm } from '@/ThemeProvider';
 
 export const IMC03103PlanGroupsEdit = ({ planGroupsDoc, onPlanPress }: PlanGroupsEditPropsInterface) => {
@@ -14,12 +16,28 @@ export const IMC03103PlanGroupsEdit = ({ planGroupsDoc, onPlanPress }: PlanGroup
 
 	// TODO: https://github.com/Ayato-kosaka/spelieve/issues/343 itinerary Plan のドラッグアンドドロップ
 
-	const { isMounted, draxItemList } = IMC03103PlanGroupsEditController({ planGroupsDoc });
+	const { isMounted, addFirstPlan, draxItemList } = IMC03103PlanGroupsEditController({ planGroupsDoc });
 
 	return (
 		<Card
 			style={{ marginVertical: '2%', marginHorizontal: '1%', backgroundColor: materialColors[primaryColorNm]['50'] }}>
 			<Card.Content>
+				{/* 先頭の Plan 追加ボタン */}
+				<IMC03102TrafficMovementEditTemplate
+					Mode={undefined}
+					Time={undefined}
+					AddPlan={
+						<Button
+							mode="outlined"
+							icon="plus"
+							// eslint-disable-next-line @typescript-eslint/no-misused-promises
+							onPress={addFirstPlan}
+							color={materialColors.grey['500']}
+							style={{ backgroundColor: 'white' }}>
+							{i18n.t('Add Plan')}
+						</Button>
+					}
+				/>
 				{draxItemList.map(({ planID, index, beforeAfterRepresentativeType, dependentPlanID }) => (
 					<View key={planID}>
 						<IMC03101PlanEdit

--- a/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03103PlanGroupEdit/PlanGroupsEditController.ts
+++ b/src/Itinerary/Contexts/ICT031PlansMap/ModelComponents/IMC03103PlanGroupEdit/PlanGroupsEditController.ts
@@ -1,5 +1,7 @@
-import { QueryDocumentSnapshot } from 'firebase/firestore';
-import { useEffect, useMemo, useState } from 'react';
+import { QueryDocumentSnapshot, setDoc } from 'firebase/firestore';
+import { useCallback, useEffect, useMemo, useState, useContext } from 'react';
+
+import { ICT031PlansMap } from '../../PlansMap';
 
 import { PlanGroupsListInterface } from '@/Itinerary/Contexts/ICT021PlanGroupsList/PlanGroupsListInterface';
 
@@ -9,12 +11,22 @@ export const IMC03103PlanGroupsEditController = ({
 	planGroupsDoc: QueryDocumentSnapshot<PlanGroupsListInterface>;
 }) => {
 	const planGroups = planGroupsDoc.data();
+	const { createPlan, plansDocSnapMap } = useContext(ICT031PlansMap);
 
 	const [isMounted, setIsMounted] = useState<boolean>(false);
 
 	useEffect(() => {
 		setIsMounted(true);
 	}, []);
+
+	const addFirstPlan = useCallback(async () => {
+		const firstPlan = plansDocSnapMap[planGroups.plans[0]].data();
+		const planDocRef = await createPlan({
+			placeStartTime: firstPlan.placeStartTime,
+			placeEndTime: firstPlan.placeStartTime,
+		});
+		await setDoc(planGroupsDoc.ref, { plans: [planDocRef.id, ...planGroups.plans] }, { merge: true });
+	}, [createPlan, planGroups.plans, planGroupsDoc.ref, plansDocSnapMap]);
 
 	const draxItemList = useMemo(() => {
 		let representativeFounded = false;
@@ -47,5 +59,5 @@ export const IMC03103PlanGroupsEditController = ({
 		});
 	}, [planGroups.plans, planGroups.representativePlanID]);
 
-	return { isMounted, draxItemList };
+	return { isMounted, addFirstPlan, draxItemList };
 };

--- a/src/Itinerary/Contexts/ICT031PlansMap/PlansMapInterface.ts
+++ b/src/Itinerary/Contexts/ICT031PlansMap/PlansMapInterface.ts
@@ -4,7 +4,7 @@ import {
 	TransitRoutingPreference,
 	TravelRestriction,
 } from '@googlemaps/google-maps-services-js';
-import { CollectionReference, QueryDocumentSnapshot } from 'firebase/firestore';
+import { CollectionReference, DocumentReference, QueryDocumentSnapshot } from 'firebase/firestore';
 
 import { Plans } from 'spelieve-common/lib/Models/Itinerary/IDB03/Plans';
 
@@ -21,4 +21,7 @@ export interface PlansMapValInterface {
 	};
 	plansCRef?: CollectionReference<PlansMapInterface>;
 	isPlansLoading: boolean;
+	createPlan: (
+		plan: Partial<Plans> & Required<Pick<Plans, 'placeStartTime' | 'placeEndTime'>>,
+	) => Promise<DocumentReference<Plans>>;
 }


### PR DESCRIPTION
## 対応内容
一番上にプランを追加
それに伴い以下改修

* IMC03103PlanGroupsEdit に 先頭の Plan 追加ボタン を追加
* addDoc での Plan を登録を切り出し、 createPlan メソッドを作成
* TrafficMoventEdit の Template を別ファイル切り出し

## エビデンス
[Spelieve-旅のしおり簡単作成アプリ-.webm](https://github.com/Ayato-kosaka/spelieve/assets/53715839/ff6c04a0-6dbf-495f-8de3-528564b23869)

