### PR TITLE
#884 Preview に URL で飛ぶと、Edit に遷移できなくなる

### DIFF
--- a/src/Common/Navigation/LinkingConfiguration.ts
+++ b/src/Common/Navigation/LinkingConfiguration.ts
@@ -34,7 +34,6 @@ const ItineraryStackScreens: Weaken<ItineraryStackParamList, keyof ItineraryStac
 	ItineraryTopTabNavigator: {
 		screens: ItineraryTopTabScreenProps,
 	},
-	EditPlan: 'EditPlan',
 	HelloSpelieve: 'HelloSpelieve',
 };
 
@@ -65,6 +64,7 @@ const RootStackScreens: Weaken<RootStackParamList, keyof RootStackParamList> = {
 		screens: ThumbnailStackScreens,
 	},
 	Modal: 'modal',
+	EditPlan: 'EditPlan',
 	NotFound: '*',
 };
 

--- a/src/Common/Navigation/Navigation.tsx
+++ b/src/Common/Navigation/Navigation.tsx
@@ -16,6 +16,7 @@ import { LinkingConfiguration } from './LinkingConfiguration';
 import { RootStackParamList, BottomTabNavigatorParamList, RootStackScreenProps } from './NavigationInterface';
 
 import { CHK006GoogleAnalytics } from '@/Common/Hooks/CHK006GoogleAnalytics/GoogleAnalytics';
+import { IPA003EditPlan } from '@/Itinerary/Pages/IPA003EditPlan';
 import { ItineraryPageNavigator } from '@/Itinerary/Pages/ItineraryPageNavigator';
 import { PlacePageNavigator } from '@/Place/Pages/PlacePageNavigator/PlacePageNavigator';
 import { navigationTheme } from '@/ThemeProvider';
@@ -86,6 +87,12 @@ const RootNavigator = () => (
 			<Stack.Screen name="NotFound" component={NotFoundScreen} options={{ title: 'Oops!' }} />
 			<Stack.Group screenOptions={{ presentation: 'modal' }}>
 				<Stack.Screen name="Modal" component={ModalScreen} />
+				<Stack.Screen
+					name="EditPlan"
+					component={IPA003EditPlan}
+					initialParams={{}}
+					options={{ title: i18n.t('Plan setting') }}
+				/>
 			</Stack.Group>
 		</Stack.Navigator>
 	</CCO001GlobalContext>

--- a/src/Common/Navigation/NavigationInterface.ts
+++ b/src/Common/Navigation/NavigationInterface.ts
@@ -20,6 +20,7 @@ export type RootStackParamList = {
 	BottomTabNavigator: NavigatorScreenParams<BottomTabNavigatorParamList> | undefined;
 	ThumbnailPageNavigator: NavigatorScreenParams<ThumbnailStackParamList>;
 	Modal: undefined;
+	EditPlan: EditPlanPropsInterface;
 	NotFound: undefined;
 };
 
@@ -59,7 +60,6 @@ export type BottomTabNavigatorScreenProps<Screen extends keyof BottomTabNavigato
  */
 export type ItineraryStackParamList = {
 	ItineraryTopTabNavigator: NavigatorScreenParams<ItineraryTopTabParamList>;
-	EditPlan: EditPlanPropsInterface;
 	HelloSpelieve: Record<string, never>;
 };
 

--- a/src/Itinerary/Contexts/ICT011ItineraryOne/ItineraryOne.tsx
+++ b/src/Itinerary/Contexts/ICT011ItineraryOne/ItineraryOne.tsx
@@ -1,14 +1,11 @@
-import { onSnapshot, DocumentSnapshot, collection, doc } from 'firebase/firestore';
+import { onSnapshot, DocumentSnapshot, doc } from 'firebase/firestore';
 import { useState, createContext, useEffect, ReactNode, useMemo } from 'react';
 
-import { Itineraries } from 'spelieve-common/lib/Models/Itinerary/IDB01/Itineraries';
-import { FirestoreConverter } from 'spelieve-common/lib/Utils/FirestoreConverter';
-
+import { ICT011ItineraryOneController } from './ItineraryOneController';
 import { ItineraryOneInterface, ItineraryOneValInterface } from './ItineraryOneIntereface';
 
 import { consoleError, Logger } from '@/Common/Hooks/CHK001Utils';
 import { storeRecentItinerary } from '@/Common/Pages/CPA001HelloSpelieve/HelloSpelieveRecentItineraryHook';
-import db from '@/Itinerary/Endpoint/firestore';
 
 export const ICT011ItineraryOne = createContext({} as ItineraryOneValInterface);
 
@@ -18,20 +15,7 @@ export const ICT011ItineraryOneProvider = ({ children }: { children: ReactNode }
 		undefined,
 	);
 
-	const itineraryCRef = useMemo(
-		() =>
-			collection(db, Itineraries.modelName).withConverter(
-				FirestoreConverter<Itineraries, ItineraryOneInterface>(
-					Itineraries,
-					(data) => data,
-					(data) => {
-						Logger('IDB01/Itineraries', 'write', data);
-						return data;
-					},
-				),
-			),
-		[],
-	);
+	const { itineraryCRef } = ICT011ItineraryOneController();
 
 	useEffect(() => {
 		setItineraryDocSnap(undefined);

--- a/src/Itinerary/Contexts/ICT011ItineraryOne/ItineraryOneController.ts
+++ b/src/Itinerary/Contexts/ICT011ItineraryOne/ItineraryOneController.ts
@@ -1,0 +1,30 @@
+import { collection } from 'firebase/firestore';
+import { useMemo } from 'react';
+
+import { Itineraries } from 'spelieve-common/lib/Models/Itinerary/IDB01/Itineraries';
+import { FirestoreConverter } from 'spelieve-common/lib/Utils/FirestoreConverter';
+
+import { ItineraryOneInterface } from './ItineraryOneIntereface';
+
+import { Logger } from '@/Common/Hooks/CHK001Utils';
+import db from '@/Itinerary/Endpoint/firestore';
+
+export const ICT011ItineraryOneController = () => {
+	const itineraryCRef = useMemo(
+		() =>
+			collection(db, Itineraries.modelName).withConverter(
+				FirestoreConverter<Itineraries, ItineraryOneInterface>(
+					Itineraries,
+					(data) => data,
+					(data) => {
+						Logger('IDB01/Itineraries', 'write', data);
+						return data;
+					},
+				),
+			),
+		[],
+	);
+	return {
+		itineraryCRef,
+	};
+};

--- a/src/Itinerary/Contexts/ICT021PlanGroupsList/PlanGroupsList.tsx
+++ b/src/Itinerary/Contexts/ICT021PlanGroupsList/PlanGroupsList.tsx
@@ -1,10 +1,10 @@
-import { collection, query, QuerySnapshot, onSnapshot, addDoc, orderBy, setDoc, deleteDoc } from 'firebase/firestore';
+import { query, QuerySnapshot, onSnapshot, addDoc, orderBy, setDoc, deleteDoc } from 'firebase/firestore';
 import { useState, createContext, useEffect, useContext, useMemo, ReactNode, useCallback } from 'react';
 
 import { PlanGroups } from 'spelieve-common/lib/Models/Itinerary/IDB02/PlanGroups';
 import { Plans } from 'spelieve-common/lib/Models/Itinerary/IDB03/Plans';
-import { FirestoreConverter } from 'spelieve-common/lib/Utils/FirestoreConverter';
 
+import { ICT021PlanGroupsListController } from './PlanGroupsListController';
 import { PlanGroupsListInterface, PlanGroupsListValInterface } from './PlanGroupsListInterface';
 
 import { ICT011ItineraryOne } from '@/Itinerary/Contexts/ICT011ItineraryOne';
@@ -20,28 +20,7 @@ export const ICT021PlanGroupsListProvider = ({ children }: { children: ReactNode
 
 	const itinerary = useMemo(() => itineraryDocSnap?.data(), [itineraryDocSnap]);
 
-	const planGroupsCRef = useMemo(() => {
-		if (itineraryDocSnap) {
-			return collection(itineraryDocSnap.ref, PlanGroups.modelName).withConverter(
-				FirestoreConverter<PlanGroups, PlanGroupsListInterface>(
-					PlanGroups,
-					(data) => ({
-						...data,
-						dayNumber: Math.floor(
-							(data.representativeStartDateTime.getTime() - (itineraryDocSnap.data()?.startDate?.getTime() || 0)) /
-								(1000 * 60 * 60 * 24) +
-								1,
-						),
-					}),
-					(data) => ({
-						...data,
-						dayNumber: undefined,
-					}),
-				),
-			);
-		}
-		return undefined;
-	}, [itineraryDocSnap]);
+	const { planGroupsCRef } = ICT021PlanGroupsListController(itineraryDocSnap);
 
 	const createPlanGroup = useCallback(
 		async (plan?: Partial<Plans>) => {

--- a/src/Itinerary/Contexts/ICT021PlanGroupsList/PlanGroupsListController.ts
+++ b/src/Itinerary/Contexts/ICT021PlanGroupsList/PlanGroupsListController.ts
@@ -1,0 +1,35 @@
+import { collection, DocumentSnapshot } from 'firebase/firestore';
+import { useMemo } from 'react';
+
+import { Itineraries } from 'spelieve-common/lib/Models/Itinerary/IDB01/Itineraries';
+import { PlanGroups } from 'spelieve-common/lib/Models/Itinerary/IDB02/PlanGroups';
+import { FirestoreConverter } from 'spelieve-common/lib/Utils/FirestoreConverter';
+
+import { PlanGroupsListInterface } from './PlanGroupsListInterface';
+
+export const ICT021PlanGroupsListController = (itineraryDocSnap: DocumentSnapshot<Itineraries> | undefined) => {
+	const planGroupsCRef = useMemo(() => {
+		if (itineraryDocSnap) {
+			return collection(itineraryDocSnap.ref, PlanGroups.modelName).withConverter(
+				FirestoreConverter<PlanGroups, PlanGroupsListInterface>(
+					PlanGroups,
+					(data) => ({
+						...data,
+						dayNumber: Math.floor(
+							(data.representativeStartDateTime.getTime() - (itineraryDocSnap.data()?.startDate?.getTime() || 0)) /
+								(1000 * 60 * 60 * 24) +
+								1,
+						),
+					}),
+					(data) => ({
+						...data,
+						dayNumber: undefined,
+					}),
+				),
+			);
+		}
+		return undefined;
+	}, [itineraryDocSnap]);
+
+	return { planGroupsCRef };
+};

--- a/src/Itinerary/Contexts/ICT031PlansMap/PlansMap.tsx
+++ b/src/Itinerary/Contexts/ICT031PlansMap/PlansMap.tsx
@@ -1,24 +1,14 @@
-import {
-	TransitMode,
-	TravelMode,
-	TransitRoutingPreference,
-	TravelRestriction,
-} from '@googlemaps/google-maps-services-js';
-import { collection, query, onSnapshot, addDoc } from 'firebase/firestore';
+import { TransitMode, TransitRoutingPreference } from '@googlemaps/google-maps-services-js';
+import { query, onSnapshot, addDoc } from 'firebase/firestore';
 import { useState, createContext, useEffect, useMemo, useContext, ReactNode, useCallback } from 'react';
 
 import { Plans } from 'spelieve-common/lib/Models/Itinerary/IDB03/Plans';
 import * as DateUtils from 'spelieve-common/lib/Utils/DateUtils';
-import { FirestoreConverter } from 'spelieve-common/lib/Utils/FirestoreConverter';
 
-import { PlansMapInterface, PlansMapValInterface } from './PlansMapInterface';
+import { ICT031PlansMapController } from './PlansMapController';
+import { PlansMapValInterface } from './PlansMapInterface';
 
 import { ICT011ItineraryOne } from '@/Itinerary/Contexts/ICT011ItineraryOne';
-import {
-	transitModeConverter,
-	travelModeConverter,
-	travelRestrictionConverter,
-} from '@/Place/Hooks/PHK001GooglePlaceAPI';
 
 export const ICT031PlansMap = createContext({} as PlansMapValInterface);
 
@@ -28,33 +18,11 @@ export const ICT031PlansMapProvider = ({ children }: { children: ReactNode }) =>
 
 	const { itineraryDocSnap } = useContext(ICT011ItineraryOne);
 
-	const plansCRef = useMemo(() => {
-		if (itineraryDocSnap) {
-			return collection(itineraryDocSnap.ref, Plans.modelName).withConverter(
-				FirestoreConverter<Plans, PlansMapInterface>(
-					Plans,
-					(data) => ({
-						...data,
-						transportationMode: (Object.keys(travelModeConverter) as TravelMode[]).find(
-							(travelMode) => travelMode === data.transportationMode,
-						),
-						transitModes: data.transitModes
-							.map((e) => (Object.keys(transitModeConverter) as TransitMode[]).find((item) => e === item))
-							.filter((item): item is TransitMode => item !== undefined),
-						transitRoutingPreference:
-							[TransitRoutingPreference.fewer_transfers, TransitRoutingPreference.less_walking].find(
-								(transitRoutingPreference) => transitRoutingPreference === data.transitRoutingPreference,
-							) || TransitRoutingPreference.fewer_transfers,
-						avoid: data.avoid
-							.map((e) => (Object.keys(travelRestrictionConverter) as TravelRestriction[]).find((item) => e === item))
-							.filter((item): item is TravelRestriction => item !== undefined),
-					}),
-					(data) => data,
-				),
-			);
-		}
-		return undefined;
-	}, [itineraryDocSnap]);
+	const { getPlansCRef } = ICT031PlansMapController();
+	const plansCRef = useMemo(
+		() => (itineraryDocSnap ? getPlansCRef(itineraryDocSnap.ref) : undefined),
+		[getPlansCRef, itineraryDocSnap],
+	);
 
 	useEffect(() => {
 		setIsPlansLoading(true);

--- a/src/Itinerary/Contexts/ICT031PlansMap/PlansMapController.ts
+++ b/src/Itinerary/Contexts/ICT031PlansMap/PlansMapController.ts
@@ -1,0 +1,51 @@
+import {
+	TransitMode,
+	TravelMode,
+	TransitRoutingPreference,
+	TravelRestriction,
+} from '@googlemaps/google-maps-services-js';
+import { collection, DocumentReference } from 'firebase/firestore';
+import { useCallback } from 'react';
+
+import { Itineraries } from 'spelieve-common/lib/Models/Itinerary/IDB01/Itineraries';
+import { Plans } from 'spelieve-common/lib/Models/Itinerary/IDB03/Plans';
+import { FirestoreConverter } from 'spelieve-common/lib/Utils/FirestoreConverter';
+
+import { PlansMapInterface } from './PlansMapInterface';
+
+import {
+	transitModeConverter,
+	travelModeConverter,
+	travelRestrictionConverter,
+} from '@/Place/Hooks/PHK001GooglePlaceAPI';
+
+export const ICT031PlansMapController = () => {
+	const getPlansCRef = useCallback(
+		(itineraryDocumentReference: DocumentReference<Itineraries>) =>
+			collection(itineraryDocumentReference, Plans.modelName).withConverter(
+				FirestoreConverter<Plans, PlansMapInterface>(
+					Plans,
+					(data) => ({
+						...data,
+						transportationMode: (Object.keys(travelModeConverter) as TravelMode[]).find(
+							(travelMode) => travelMode === data.transportationMode,
+						),
+						transitModes: data.transitModes
+							.map((e) => (Object.keys(transitModeConverter) as TransitMode[]).find((item) => e === item))
+							.filter((item): item is TransitMode => item !== undefined),
+						transitRoutingPreference:
+							[TransitRoutingPreference.fewer_transfers, TransitRoutingPreference.less_walking].find(
+								(transitRoutingPreference) => transitRoutingPreference === data.transitRoutingPreference,
+							) || TransitRoutingPreference.fewer_transfers,
+						avoid: data.avoid
+							.map((e) => (Object.keys(travelRestrictionConverter) as TravelRestriction[]).find((item) => e === item))
+							.filter((item): item is TravelRestriction => item !== undefined),
+					}),
+					(data) => data,
+				),
+			),
+		[],
+	);
+
+	return { getPlansCRef };
+};

--- a/src/Itinerary/Navigator/INV002ItineraryTopTabNavigator/ItineraryTopTabNavigator.tsx
+++ b/src/Itinerary/Navigator/INV002ItineraryTopTabNavigator/ItineraryTopTabNavigator.tsx
@@ -5,6 +5,9 @@ import { INV002ItineraryTopTabNavigatorController } from './ItineraryTopTabNavig
 
 import i18n from '@/Common/Hooks/i18n-js';
 import { ItineraryTopTabParamList, ItineraryStackScreenProps } from '@/Common/Navigation/NavigationInterface';
+import { ICT011ItineraryOneProvider } from '@/Itinerary/Contexts/ICT011ItineraryOne';
+import { ICT021PlanGroupsListProvider } from '@/Itinerary/Contexts/ICT021PlanGroupsList';
+import { ICT031PlansMapProvider } from '@/Itinerary/Contexts/ICT031PlansMap';
 import { IPA001ItineraryEdit } from '@/Itinerary/Pages/IPA001ItineraryEdit';
 import { IPA004ItineraryPreview } from '@/Itinerary/Pages/IPA004ItineraryPreview';
 
@@ -28,19 +31,25 @@ export const INV002ItineraryTopTabNavigator = ({
 	}, [itinerary, navigation]);
 
 	return (
-		<Tab.Navigator initialRouteName="ItineraryEdit">
-			<Tab.Screen
-				name="ItineraryEdit"
-				component={IPA001ItineraryEdit}
-				initialParams={{}}
-				options={{ title: i18n.t('Edit'), lazy: true }}
-			/>
-			<Tab.Screen
-				name="ItineraryPreview"
-				component={IPA004ItineraryPreview}
-				initialParams={{}}
-				options={{ title: i18n.t('Preview'), lazy: true }}
-			/>
-		</Tab.Navigator>
+		<ICT011ItineraryOneProvider>
+			<ICT031PlansMapProvider>
+				<ICT021PlanGroupsListProvider>
+					<Tab.Navigator initialRouteName="ItineraryEdit">
+						<Tab.Screen
+							name="ItineraryEdit"
+							component={IPA001ItineraryEdit}
+							initialParams={{}}
+							options={{ title: i18n.t('Edit'), lazy: true }}
+						/>
+						<Tab.Screen
+							name="ItineraryPreview"
+							component={IPA004ItineraryPreview}
+							initialParams={{}}
+							options={{ title: i18n.t('Preview'), lazy: true }}
+						/>
+					</Tab.Navigator>
+				</ICT021PlanGroupsListProvider>
+			</ICT031PlansMapProvider>
+		</ICT011ItineraryOneProvider>
 	);
 };

--- a/src/Itinerary/Pages/IPA003EditPlan/EditPlan.tsx
+++ b/src/Itinerary/Pages/IPA003EditPlan/EditPlan.tsx
@@ -1,4 +1,3 @@
-import { setDoc } from 'firebase/firestore';
 import { ActivityIndicator, Image, Pressable, ScrollView, View } from 'react-native';
 import { Text, TextInput, Button } from 'react-native-paper';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
@@ -10,33 +9,25 @@ import { CCO003DateTimePicker } from '@/Common/Components/CCO003DateTimePicker';
 import { CCO004DurationPicker } from '@/Common/Components/CCO004DurationPicker/DurationPicker';
 import { CCO007GoogleBannerAd } from '@/Common/Components/CCO007GoogleBannerAd/GoogleBannerAd';
 import i18n from '@/Common/Hooks/i18n-js';
-import { ItineraryStackScreenProps } from '@/Common/Navigation/NavigationInterface';
+import { RootStackScreenProps } from '@/Common/Navigation/NavigationInterface';
 import { PCO002GooglePlacesAutocomplete } from '@/Place/Components/PCO002GooglePlacesAutocomplete';
+import { PCT012MPlaceOneProvider } from '@/Place/Contexts/PCT012MPlaceOne';
 import { PMC01202PlaceInformation } from '@/Place/Contexts/PCT012MPlaceOne/ModelComponents/PMC01202PlaceInformation/PlaceInformation';
 
-export const IPA003EditPlan = ({ route, navigation }: ItineraryStackScreenProps<'EditPlan'>) => {
+export const IPA003EditPlanBody = ({ route, navigation }: RootStackScreenProps<'EditPlan'>) => {
 	const {
 		planGroup,
-		planDocSnap,
-		pagePlan,
 		isRepresentativePlan,
-		isNeedToShowActivityIndicator,
-		isNeedToNavigateToItineraryEdit,
-		navigateToItineraryEdit,
-		updatePlan,
+		plan,
 		onPressThumbnail,
 		updateRepresentativeStartDateTime,
 		setPlanToRepresentativePlan,
 		onAutocompleteClicked,
 		onChangeMemo,
+		onBlurSpan,
 	} = IPA003EditPlanController({ route, navigation });
 
-	if (isNeedToShowActivityIndicator) {
-		return <ActivityIndicator animating />;
-	}
-
-	if (isNeedToNavigateToItineraryEdit) {
-		navigateToItineraryEdit();
+	if (planGroup === undefined || plan === undefined) {
 		return <ActivityIndicator animating />;
 	}
 
@@ -50,7 +41,7 @@ export const IPA003EditPlan = ({ route, navigation }: ItineraryStackScreenProps<
 					color="rgba(0,0,0,0.5)"
 					style={styles.materialCommunityIcons}
 				/>
-				<Image source={{ uri: pagePlan.imageUrl }} resizeMode="cover" style={styles.image} />
+				<Image source={{ uri: plan.imageUrl }} resizeMode="cover" style={styles.image} />
 			</Pressable>
 			<PCO002GooglePlacesAutocomplete
 				onAutocompleteClicked={onAutocompleteClicked}
@@ -58,17 +49,12 @@ export const IPA003EditPlan = ({ route, navigation }: ItineraryStackScreenProps<
 				fetchDetails={false}
 				placeholder={i18n.t('Search Place')}
 			/>
-			<TextInput
-				label={i18n.t('Memo')}
-				value={pagePlan.memo}
-				onChange={onChangeMemo}
-				onBlur={updatePlan}
-				style={styles.memoTextInput}
-			/>
+			{/* TextInput.props.value に undefined を設定するとエラーになる。本来は DB を必須にすべき？ */}
+			<TextInput label={i18n.t('Memo')} value={plan.memo || ''} onChange={onChangeMemo} style={styles.memoTextInput} />
 			<CCO004DurationPicker
-				value={pagePlan.placeSpan}
+				value={plan.placeSpan}
 				label={i18n.t('Stay time')}
-				onBlur={(newVal) => setDoc(planDocSnap!.ref, { placeSpan: newVal }, { merge: true })}
+				onBlur={onBlurSpan}
 				style={styles.spanTextInput}
 			/>
 
@@ -82,13 +68,13 @@ export const IPA003EditPlan = ({ route, navigation }: ItineraryStackScreenProps<
 					<View style={{ flexDirection: 'row' }}>
 						<CCO003DateTimePicker
 							style={styles.representativeStartDateTimePicker}
-							value={planGroup!.representativeStartDateTime}
+							value={planGroup.representativeStartDateTime}
 							onChange={updateRepresentativeStartDateTime}
 							mode="date"
 						/>
 						<CCO003DateTimePicker
 							style={styles.representativeStartDateTimePicker}
-							value={planGroup!.representativeStartDateTime}
+							value={planGroup.representativeStartDateTime}
 							onChange={updateRepresentativeStartDateTime}
 							mode="time"
 						/>
@@ -104,3 +90,9 @@ export const IPA003EditPlan = ({ route, navigation }: ItineraryStackScreenProps<
 		</ScrollView>
 	);
 };
+
+export const IPA003EditPlan = ({ route, navigation }: RootStackScreenProps<'EditPlan'>) => (
+	<PCT012MPlaceOneProvider>
+		<IPA003EditPlanBody route={route} navigation={navigation} />
+	</PCT012MPlaceOneProvider>
+);

--- a/src/Itinerary/Pages/ItineraryPageNavigator.tsx
+++ b/src/Itinerary/Pages/ItineraryPageNavigator.tsx
@@ -1,46 +1,25 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { ICT011ItineraryOneProvider } from '../Contexts/ICT011ItineraryOne';
-import { ICT021PlanGroupsListProvider } from '../Contexts/ICT021PlanGroupsList';
-import { ICT031PlansMapProvider } from '../Contexts/ICT031PlansMap';
 import { INV002ItineraryTopTabNavigator } from '../Navigator/INV002ItineraryTopTabNavigator';
 
-import { IPA003EditPlan } from './IPA003EditPlan';
-
-import i18n from '@/Common/Hooks/i18n-js';
 import { BottomTabNavigatorScreenProps, ItineraryStackParamList } from '@/Common/Navigation/NavigationInterface';
 import { CPA001HelloSpelieve } from '@/Common/Pages/CPA001HelloSpelieve/HelloSpelieve';
-import { PCT012MPlaceOneProvider } from '@/Place/Contexts/PCT012MPlaceOne';
 
 const Stack = createNativeStackNavigator<ItineraryStackParamList>();
 
 export const ItineraryPageNavigator = ({ navigation, route }: BottomTabNavigatorScreenProps<'Itinerary'>) => (
-	<ICT011ItineraryOneProvider>
-		<ICT031PlansMapProvider>
-			<ICT021PlanGroupsListProvider>
-				<PCT012MPlaceOneProvider>
-					<Stack.Navigator initialRouteName="HelloSpelieve">
-						<Stack.Screen
-							name="ItineraryTopTabNavigator"
-							component={INV002ItineraryTopTabNavigator}
-							initialParams={{}}
-							options={{ title: '' }}
-						/>
-						<Stack.Screen
-							name="EditPlan"
-							component={IPA003EditPlan}
-							initialParams={{}}
-							options={{ title: i18n.t('Plan setting') }}
-						/>
-						<Stack.Screen
-							name="HelloSpelieve"
-							component={CPA001HelloSpelieve}
-							initialParams={{}}
-							options={{ headerShown: false }}
-						/>
-					</Stack.Navigator>
-				</PCT012MPlaceOneProvider>
-			</ICT021PlanGroupsListProvider>
-		</ICT031PlansMapProvider>
-	</ICT011ItineraryOneProvider>
+	<Stack.Navigator initialRouteName="HelloSpelieve">
+		<Stack.Screen
+			name="ItineraryTopTabNavigator"
+			component={INV002ItineraryTopTabNavigator}
+			initialParams={{}}
+			options={{ title: '' }}
+		/>
+		<Stack.Screen
+			name="HelloSpelieve"
+			component={CPA001HelloSpelieve}
+			initialParams={{}}
+			options={{ headerShown: false }}
+		/>
+	</Stack.Navigator>
 );


### PR DESCRIPTION
## 対応内容
* ICT011ItineraryOneProvider, ICT031PlansMapProvider, ICT021PlanGroupsListProvider を ItineraryPageNavigator 直下から INV002ItineraryTopTabNavigator 直下に移動
* IPA003EditPlan を INV002ItineraryTopTabNavigator 直下から modal に移動
* PCT012MPlaceOneProvider を INV002ItineraryTopTabNavigator 直下から IPA003EditPlan 直下に移動
* itineraryCRef, planGroupsCRef, getPlansCRef を ContextController に切り出し
* ICT 階層から外れたため、IPA003EditPlan の作り直し

## 単体テストエビデンス
https://miro.com/app/board/uXjVNL6262U=/