### PR TITLE
#898 【BUG】ItineraryEdit or ItineraryPreview に URL で遷移した場合、 HelloSpeli…

### DIFF
--- a/src/Itinerary/Pages/ItineraryPageNavigator.tsx
+++ b/src/Itinerary/Pages/ItineraryPageNavigator.tsx
@@ -1,25 +1,61 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useCallback } from 'react';
+import { Pressable, Text } from 'react-native';
 
 import { INV002ItineraryTopTabNavigator } from '../Navigator/INV002ItineraryTopTabNavigator';
 
 import { BottomTabNavigatorScreenProps, ItineraryStackParamList } from '@/Common/Navigation/NavigationInterface';
 import { CPA001HelloSpelieve } from '@/Common/Pages/CPA001HelloSpelieve/HelloSpelieve';
+import { materialColors } from '@/ThemeProvider';
 
 const Stack = createNativeStackNavigator<ItineraryStackParamList>();
 
-export const ItineraryPageNavigator = ({ navigation, route }: BottomTabNavigatorScreenProps<'Itinerary'>) => (
-	<Stack.Navigator initialRouteName="HelloSpelieve">
-		<Stack.Screen
-			name="ItineraryTopTabNavigator"
-			component={INV002ItineraryTopTabNavigator}
-			initialParams={{}}
-			options={{ title: '' }}
-		/>
-		<Stack.Screen
-			name="HelloSpelieve"
-			component={CPA001HelloSpelieve}
-			initialParams={{}}
-			options={{ headerShown: false }}
-		/>
-	</Stack.Navigator>
-);
+export const ItineraryPageNavigator = ({ navigation, route }: BottomTabNavigatorScreenProps<'Itinerary'>) => {
+	const headerTitle = useCallback(
+		() => (
+			<Pressable
+				onPress={() =>
+					navigation.navigate('Itinerary', {
+						screen: 'HelloSpelieve',
+						params: {},
+					})
+				}>
+				<Text
+					style={{
+						color: 'white',
+						fontSize: 30,
+						fontWeight: 'bold',
+						fontFamily: 'Verdana',
+					}}>
+					Spelieve
+				</Text>
+			</Pressable>
+		),
+		[navigation],
+	);
+	return (
+		<Stack.Navigator
+			initialRouteName="HelloSpelieve"
+			screenOptions={{
+				headerStyle: {
+					backgroundColor: materialColors.orange['500'],
+				},
+				headerTitle,
+				headerTitleAlign: 'center',
+				headerLeft: () => null,
+			}}>
+			<Stack.Screen
+				name="ItineraryTopTabNavigator"
+				component={INV002ItineraryTopTabNavigator}
+				initialParams={{}}
+				options={{ title: '' }}
+			/>
+			<Stack.Screen
+				name="HelloSpelieve"
+				component={CPA001HelloSpelieve}
+				initialParams={{}}
+				options={{ headerShown: false }}
+			/>
+		</Stack.Navigator>
+	);
+};


### PR DESCRIPTION
…eve に戻る手段がない

## 対応内容
* ItineraryPageNavigator に Header をカスタマイズし、 Hello Spelieve に遷移するボタンを追加
* 戻るボタンは消去

## エビデンス

https://github.com/Ayato-kosaka/spelieve/assets/53715839/64a5abca-c8c5-4584-ae25-3aacd18b7dfd

* ItineraryEdit の Header をカスタマイズし、 Hello Spelieve に遷移するボタンがある
* 戻るボタンは消えている
* URL から入っても HelloSpelieve に遷移できる